### PR TITLE
Deprecated the Item interface

### DIFF
--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -25,11 +25,11 @@ dependencies {
 
 ## 使用
 
-#### Step 1. 创建一个 class __implements__ `Item`，它将是你的数据类型或 `Java bean`，示例：
+#### Step 1. 创建一个 class，它将是你的数据类型或 `Java bean`，示例：
 
 
 ```java
-public class TextItem implements Item {
+public class TextItem {
 
     @NonNull public String text;
 
@@ -39,7 +39,7 @@ public class TextItem implements Item {
 }
 ```
 
-#### Step 2. 创建一个 class 继承  `ItemViewProvider<C extends Item, V extends ViewHolder>`，示例：
+#### Step 2. 创建一个 class 继承  `ItemViewProvider<C, V extends ViewHolder>`，示例：
 
 
 ```java
@@ -69,7 +69,7 @@ public class TextItemViewProvider
 }
 ```
 
-#### Step 3. 好了，你不必再创建新的类文件了，在 `Activity` 中加入 `RecyclerView` 和 `List<Item>` 并注册你都类型即可，示例：
+#### Step 3. 好了，你不必再创建新的类文件了，在 `Activity` 中加入 `RecyclerView` 和 `List<Object>` 并注册你都类型即可，示例：
 
 
 ```java

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ In your `build.gradle`:
 
 ```groovy
 dependencies {
-    compile 'me.drakeet.multitype:multitype:2.2.1'
+    compile 'me.drakeet.multitype:multitype:2.2.2'
 }
 ```
 
 ## Usage
 
-#### Step 1. Create a class __implements__ `Item`, It would be your `data model`/`Java bean`, for example:
+#### Step 1. Create a class, It would be your `data model`/`Java bean`, for example:
 
 ```java
-public class TextItem implements Item {
+public class TextItem {
 
     @NonNull public String text;
 
@@ -41,7 +41,7 @@ public class TextItem implements Item {
 }
 ```
 
-#### Step 2. Create a class extends `ItemViewProvider<C extends Item, V extends ViewHolder>`, for example:
+#### Step 2. Create a class extends `ItemViewProvider<C, V extends ViewHolder>`, for example:
 
 ```java
 public class TextItemViewProvider
@@ -70,7 +70,7 @@ public class TextItemViewProvider
 }
 ```
 
-#### Step 3. You do not need to create another new class. Just `register` your types and add a `RecyclerView` and `List<Item>` to your `Activity`, for example:
+#### Step 3. You do not need to create another new class. Just `register` your types and add a `RecyclerView` and `List<Object>` to your `Activity`, for example:
 
 ```java
 public class NormalActivity extends AppCompatActivity {

--- a/library/src/main/java/me/drakeet/multitype/FlatTypeAdapter.java
+++ b/library/src/main/java/me/drakeet/multitype/FlatTypeAdapter.java
@@ -23,7 +23,7 @@ import android.support.annotation.NonNull;
  */
 public interface FlatTypeAdapter {
 
-    @NonNull Class onFlattenClass(@NonNull Item item);
+    @NonNull Class onFlattenClass(@NonNull Object item);
 
-    @NonNull Item onFlattenItem(@NonNull final Item item);
+    @NonNull Object onFlattenItem(@NonNull final Object item);
 }

--- a/library/src/main/java/me/drakeet/multitype/GlobalMultiTypePool.java
+++ b/library/src/main/java/me/drakeet/multitype/GlobalMultiTypePool.java
@@ -28,17 +28,17 @@ public class GlobalMultiTypePool {
 
 
     public static void register(
-        @NonNull Class<? extends Item> clazz, @NonNull ItemViewProvider provider) {
+        @NonNull Class<?> clazz, @NonNull ItemViewProvider provider) {
         pool.register(clazz, provider);
     }
 
 
-    public static int indexOf(@NonNull Class<? extends Item> clazz) {
+    public static int indexOf(@NonNull Class<?> clazz) {
         return pool.indexOf(clazz);
     }
 
 
-    @NonNull public static ArrayList<Class<? extends Item>> getContents() {
+    @NonNull public static ArrayList<Class<?>> getContents() {
         return pool.getContents();
     }
 
@@ -54,7 +54,7 @@ public class GlobalMultiTypePool {
 
 
     @NonNull public static <T extends ItemViewProvider> T getProviderByClass(
-        @NonNull Class<? extends Item> clazz) {
+        @NonNull Class<?> clazz) {
         return pool.getProviderByClass(clazz);
     }
 

--- a/library/src/main/java/me/drakeet/multitype/Item.java
+++ b/library/src/main/java/me/drakeet/multitype/Item.java
@@ -17,8 +17,11 @@
 package me.drakeet.multitype;
 
 /**
+ * {@link Item} has been Deprecated, use {@link Object} instead.
+ * However you could keep it and it is useless and harmless.
+ *
  * @author drakeet
  */
+@Deprecated
 public interface Item {
-
 }

--- a/library/src/main/java/me/drakeet/multitype/ItemViewProvider.java
+++ b/library/src/main/java/me/drakeet/multitype/ItemViewProvider.java
@@ -24,7 +24,7 @@ import android.view.ViewGroup;
 /***
  * @author drakeet
  */
-public abstract class ItemViewProvider<C extends Item, V extends ViewHolder> {
+public abstract class ItemViewProvider<C, V extends ViewHolder> {
 
     /* @formatter:off */
 

--- a/library/src/main/java/me/drakeet/multitype/Items.java
+++ b/library/src/main/java/me/drakeet/multitype/Items.java
@@ -21,5 +21,5 @@ import java.util.ArrayList;
 /**
  * @author drakeet
  */
-public class Items extends ArrayList<Item> {
+public class Items extends ArrayList<Object> {
 }

--- a/library/src/main/java/me/drakeet/multitype/MultiTypeAdapter.java
+++ b/library/src/main/java/me/drakeet/multitype/MultiTypeAdapter.java
@@ -30,36 +30,36 @@ import java.util.List;
 public class MultiTypeAdapter extends RecyclerView.Adapter<ViewHolder>
     implements FlatTypeAdapter, TypePool {
 
-    protected final List<? extends Item> items;
+    protected final List<?> items;
     protected LayoutInflater inflater;
     protected TypePool delegate;
 
 
-    public MultiTypeAdapter(@NonNull List<? extends Item> items) {
+    public MultiTypeAdapter(@NonNull List<?> items) {
         this.delegate = new MultiTypePool();
         this.items = items;
     }
 
 
-    public MultiTypeAdapter(@NonNull List<? extends Item> items, TypePool pool) {
+    public MultiTypeAdapter(@NonNull List<?> items, TypePool pool) {
         this.delegate = pool;
         this.items = items;
     }
 
 
-    @NonNull @Override public Class onFlattenClass(@NonNull final Item item) {
+    @NonNull @Override public Class onFlattenClass(@NonNull final Object item) {
         return item.getClass();
     }
 
 
-    @NonNull @Override public Item onFlattenItem(@NonNull final Item item) {
+    @NonNull @Override public Object onFlattenItem(@NonNull final Object item) {
         return item;
     }
 
 
     @SuppressWarnings("unchecked") @Override
     public int getItemViewType(int position) {
-        Item item = items.get(position);
+        Object item = items.get(position);
         return indexOf(onFlattenClass(item));
     }
 
@@ -74,7 +74,7 @@ public class MultiTypeAdapter extends RecyclerView.Adapter<ViewHolder>
 
     @SuppressWarnings("unchecked") @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        Item item = items.get(position);
+        Object item = items.get(position);
         getProviderByClass(onFlattenClass(item)).onBindViewHolder(holder, onFlattenItem(item));
     }
 
@@ -86,7 +86,7 @@ public class MultiTypeAdapter extends RecyclerView.Adapter<ViewHolder>
 
     public void applyGlobalMultiTypePool() {
         for (int i = 0; i < GlobalMultiTypePool.getContents().size(); i++) {
-            final Class<? extends Item> clazz = GlobalMultiTypePool.getContents().get(i);
+            final Class<?> clazz = GlobalMultiTypePool.getContents().get(i);
             final ItemViewProvider provider = GlobalMultiTypePool.getProviders().get(i);
             if (!this.getContents().contains(clazz)) {
                 this.register(clazz, provider);
@@ -103,12 +103,12 @@ public class MultiTypeAdapter extends RecyclerView.Adapter<ViewHolder>
 
 
     @Override
-    public void register(@NonNull Class<? extends Item> clazz, @NonNull ItemViewProvider provider) {
+    public void register(@NonNull Class<?> clazz, @NonNull ItemViewProvider provider) {
         delegate.register(clazz, provider);
     }
 
 
-    @Override public int indexOf(@NonNull Class<? extends Item> clazz)
+    @Override public int indexOf(@NonNull Class<?> clazz)
         throws ProviderNotFoundException {
         int index = delegate.indexOf(clazz);
         if (index >= 0) {
@@ -118,7 +118,7 @@ public class MultiTypeAdapter extends RecyclerView.Adapter<ViewHolder>
     }
 
 
-    @NonNull @Override public ArrayList<Class<? extends Item>> getContents() {
+    @NonNull @Override public ArrayList<Class<?>> getContents() {
         return delegate.getContents();
     }
 
@@ -134,8 +134,7 @@ public class MultiTypeAdapter extends RecyclerView.Adapter<ViewHolder>
 
 
     @NonNull @Override
-    public <T extends ItemViewProvider> T getProviderByClass(
-        @NonNull Class<? extends Item> clazz) {
+    public <T extends ItemViewProvider> T getProviderByClass(@NonNull Class<?> clazz) {
         return delegate.getProviderByClass(clazz);
     }
 }

--- a/library/src/main/java/me/drakeet/multitype/MultiTypeAsserts.java
+++ b/library/src/main/java/me/drakeet/multitype/MultiTypeAsserts.java
@@ -39,13 +39,13 @@ public class MultiTypeAsserts {
     @SuppressWarnings("unchecked")
     public static void assertAllRegistered(
         @NonNull MultiTypeAdapter adapter,
-        @NonNull List<? extends Item> items)
+        @NonNull List<?> items)
         throws ProviderNotFoundException, IllegalArgumentException, IllegalAccessError {
 
         if (items.size() == 0) {
             throw new IllegalArgumentException("Your Items/List is empty.");
         }
-        for (Item item : items) {
+        for (Object item : items) {
             adapter.indexOf(adapter.onFlattenClass(item));
         }
         /* All passed. */

--- a/library/src/main/java/me/drakeet/multitype/MultiTypePool.java
+++ b/library/src/main/java/me/drakeet/multitype/MultiTypePool.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 public final class MultiTypePool implements TypePool {
 
     private final String TAG = MultiTypePool.class.getSimpleName();
-    private ArrayList<Class<? extends Item>> contents;
+    private ArrayList<Class<?>> contents;
     private ArrayList<ItemViewProvider> providers;
 
 
@@ -37,7 +37,7 @@ public final class MultiTypePool implements TypePool {
 
 
     public void register(
-        @NonNull Class<? extends Item> clazz,
+        @NonNull Class<?> clazz,
         @NonNull ItemViewProvider provider) {
         if (!contents.contains(clazz)) {
             contents.add(clazz);
@@ -51,7 +51,7 @@ public final class MultiTypePool implements TypePool {
     }
 
 
-    @Override public int indexOf(@NonNull final Class<? extends Item> clazz) {
+    @Override public int indexOf(@NonNull final Class<?> clazz) {
         int index = contents.indexOf(clazz);
         if (index >= 0) {
             return index;
@@ -65,7 +65,7 @@ public final class MultiTypePool implements TypePool {
     }
 
 
-    @NonNull @Override public ArrayList<Class<? extends Item>> getContents() {
+    @NonNull @Override public ArrayList<Class<?>> getContents() {
         return contents;
     }
 
@@ -81,8 +81,7 @@ public final class MultiTypePool implements TypePool {
 
 
     @SuppressWarnings("unchecked") @NonNull @Override
-    public <T extends ItemViewProvider> T getProviderByClass(
-        @NonNull final Class<? extends Item> clazz) {
+    public <T extends ItemViewProvider> T getProviderByClass(@NonNull final Class<?> clazz) {
         return (T) getProviderByIndex(indexOf(clazz));
     }
 }

--- a/library/src/main/java/me/drakeet/multitype/ProviderNotFoundException.java
+++ b/library/src/main/java/me/drakeet/multitype/ProviderNotFoundException.java
@@ -21,7 +21,7 @@ package me.drakeet.multitype;
  */
 public class ProviderNotFoundException extends RuntimeException {
 
-    public ProviderNotFoundException(Class<? extends Item> clazz) {
+    public ProviderNotFoundException(Class<?> clazz) {
         super("Do you have registered the provider for {className}.class in the adapter/pool?"
             .replace("{className}", clazz.getSimpleName()));
     }

--- a/library/src/main/java/me/drakeet/multitype/TypePool.java
+++ b/library/src/main/java/me/drakeet/multitype/TypePool.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
  */
 public interface TypePool {
 
-    void register(@NonNull Class<? extends Item> clazz, @NonNull ItemViewProvider provider);
+    void register(@NonNull Class<?> clazz, @NonNull ItemViewProvider provider);
 
     /**
      * For getting index of the item class.
@@ -37,14 +37,14 @@ public interface TypePool {
      * @return the index of the first occurrence of the specified element
      * in this list, or -1 if this list does not contain the element.
      */
-    int indexOf(@NonNull Class<? extends Item> clazz);
+    int indexOf(@NonNull Class<?> clazz);
 
-    @NonNull ArrayList<Class<? extends Item>> getContents();
+    @NonNull ArrayList<Class<?>> getContents();
 
     @NonNull ArrayList<ItemViewProvider> getProviders();
 
     @NonNull ItemViewProvider getProviderByIndex(int index);
 
     @NonNull <T extends ItemViewProvider> T getProviderByClass(
-        @NonNull Class<? extends Item> clazz);
+        @NonNull Class<?> clazz);
 }

--- a/sample/src/main/java/me/drakeet/multitype/sample/bilibili/BilibiliActivity.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/bilibili/BilibiliActivity.java
@@ -24,7 +24,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import java.util.ArrayList;
 import java.util.List;
-import me.drakeet.multitype.Item;
 import me.drakeet.multitype.MultiTypeAdapter;
 import me.drakeet.multitype.sample.MenuBaseActivity;
 import me.drakeet.multitype.sample.R;
@@ -38,7 +37,7 @@ import static me.drakeet.multitype.MultiTypeAsserts.assertAllRegistered;
 public class BilibiliActivity extends MenuBaseActivity {
 
     private static final int SPAN_COUNT = 2;
-    private List<Item> items;
+    private List<Object> items;
     private MultiTypeAdapter adapter;
 
 
@@ -96,7 +95,7 @@ public class BilibiliActivity extends MenuBaseActivity {
         SpanSizeLookup spanSizeLookup = new SpanSizeLookup() {
             @Override
             public int getSpanSize(int position) {
-                Item item = items.get(position);
+                Object item = items.get(position);
                 return (item instanceof PostList || item instanceof Category) ? SPAN_COUNT : 1;
             }
         };

--- a/sample/src/main/java/me/drakeet/multitype/sample/bilibili/Post.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/bilibili/Post.java
@@ -17,12 +17,11 @@
 package me.drakeet.multitype.sample.bilibili;
 
 import android.support.annotation.NonNull;
-import me.drakeet.multitype.Item;
 
 /**
  * @author drakeet
  */
-public class Post implements Item {
+public class Post {
 
     public int coverResId;
     public String title;

--- a/sample/src/main/java/me/drakeet/multitype/sample/bilibili/PostList.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/bilibili/PostList.java
@@ -18,12 +18,11 @@ package me.drakeet.multitype.sample.bilibili;
 
 import android.support.annotation.NonNull;
 import java.util.List;
-import me.drakeet.multitype.Item;
 
 /**
  * @author drakeet
  */
-public class PostList implements Item {
+public class PostList {
 
     final List<Post> posts;
 

--- a/sample/src/main/java/me/drakeet/multitype/sample/common/Category.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/common/Category.java
@@ -17,12 +17,11 @@
 package me.drakeet.multitype.sample.common;
 
 import android.support.annotation.NonNull;
-import me.drakeet.multitype.Item;
 
 /**
  * @author drakeet
  */
-public class Category implements Item {
+public class Category {
 
     public String title;
 

--- a/sample/src/main/java/me/drakeet/multitype/sample/multi_select/Square.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/multi_select/Square.java
@@ -16,12 +16,10 @@
 
 package me.drakeet.multitype.sample.multi_select;
 
-import me.drakeet.multitype.Item;
-
 /**
  * @author drakeet
  */
-public class Square implements Item {
+public class Square {
 
     public final int number;
     public boolean isSelected;

--- a/sample/src/main/java/me/drakeet/multitype/sample/normal/ImageItem.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/normal/ImageItem.java
@@ -16,12 +16,10 @@
 
 package me.drakeet.multitype.sample.normal;
 
-import me.drakeet.multitype.Item;
-
 /**
  * @author drakeet
  */
-public class ImageItem implements Item {
+public class ImageItem {
 
     public final int resId;
 

--- a/sample/src/main/java/me/drakeet/multitype/sample/normal/NormalActivity.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/normal/NormalActivity.java
@@ -18,7 +18,8 @@ package me.drakeet.multitype.sample.normal;
 
 import android.os.Bundle;
 import android.support.v7.widget.RecyclerView;
-import me.drakeet.multitype.Items;
+import java.util.ArrayList;
+import java.util.List;
 import me.drakeet.multitype.MultiTypeAdapter;
 import me.drakeet.multitype.sample.MenuBaseActivity;
 import me.drakeet.multitype.sample.R;
@@ -29,7 +30,7 @@ import me.drakeet.multitype.sample.R;
 public class NormalActivity extends MenuBaseActivity {
 
     private MultiTypeAdapter adapter;
-    private Items items;
+    private List<Object> items;
 
 
     @Override protected void onCreate(Bundle savedInstanceState) {
@@ -37,7 +38,7 @@ public class NormalActivity extends MenuBaseActivity {
         setContentView(R.layout.activity_list);
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.list);
 
-        items = new Items();
+        items = new ArrayList<>();
         adapter = new MultiTypeAdapter(items);
         adapter.applyGlobalMultiTypePool();
         adapter.register(RichItem.class, new RichItemViewProvider());

--- a/sample/src/main/java/me/drakeet/multitype/sample/normal/RichItem.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/normal/RichItem.java
@@ -17,12 +17,11 @@
 package me.drakeet.multitype.sample.normal;
 
 import android.support.annotation.NonNull;
-import me.drakeet.multitype.Item;
 
 /**
  * @author drakeet
  */
-public class RichItem implements Item {
+public class RichItem {
 
     @NonNull public String text;
     public int imageResId;

--- a/sample/src/main/java/me/drakeet/multitype/sample/normal/TextItem.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/normal/TextItem.java
@@ -18,13 +18,12 @@ package me.drakeet.multitype.sample.normal;
 
 import android.support.annotation.NonNull;
 import com.google.gson.Gson;
-import me.drakeet.multitype.Item;
 import me.drakeet.multitype.sample.Savable;
 
 /**
  * @author drakeet
  */
-public class TextItem implements Item, Savable {
+public class TextItem implements Savable {
 
     @NonNull public String text;
 

--- a/sample/src/main/java/me/drakeet/multitype/sample/weibo/Weibo.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/weibo/Weibo.java
@@ -17,12 +17,11 @@
 package me.drakeet.multitype.sample.weibo;
 
 import android.support.annotation.NonNull;
-import me.drakeet.multitype.Item;
 
 /**
  * @author drakeet
  */
-public class Weibo implements Item {
+public class Weibo {
 
     @NonNull public User user;
     @NonNull public WeiboContent content;

--- a/sample/src/main/java/me/drakeet/multitype/sample/weibo/WeiboAdapter.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/weibo/WeiboAdapter.java
@@ -27,7 +27,7 @@ import me.drakeet.multitype.TypePool;
  */
 public class WeiboAdapter extends MultiTypeAdapter {
 
-    public WeiboAdapter(@NonNull List<? extends Item> items) {
+    public WeiboAdapter(@NonNull List<?> items) {
         super(items);
     }
 
@@ -37,7 +37,7 @@ public class WeiboAdapter extends MultiTypeAdapter {
     }
 
 
-    @NonNull @Override public Class onFlattenClass(@NonNull Item item) {
+    @NonNull @Override public Class onFlattenClass(@NonNull Object item) {
         return ((Weibo) item).content.getClass();
     }
 }

--- a/sample/src/main/java/me/drakeet/multitype/sample/weibo/WeiboContent.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/weibo/WeiboContent.java
@@ -18,12 +18,11 @@ package me.drakeet.multitype.sample.weibo;
 
 import android.support.annotation.NonNull;
 import com.google.gson.annotations.SerializedName;
-import me.drakeet.multitype.Item;
 
 /**
  * @author drakeet
  */
-public abstract class WeiboContent implements Item {
+public abstract class WeiboContent {
 
     @SerializedName("content_type")
     @NonNull public final String contentType;


### PR DESCRIPTION
Finally, I decided to discard the `Item` interface. It brings meaning can not offset the trouble it brings. So, I use `Object` to instead of it, and keep the interface but `Deprecated` so that we don't change our old type classes, the `Item` is useless and harmless now.

Chinese:

对于 MultiType `Item` 这个接口，最后我决定抛弃它，因为它带来的意义无法抵消它带来的麻烦，比如我们无法在一个纯 java module 里定义我们的 item types（若要如此，这个 module 势必要引用 MultiType，但实际上它不应该引用任何 Android library）；另外，对于嵌套 item class，从面向对象观点看来它们不应该实现 `Item` 接口。因此现在使用 `Object` 替代 `Item`，但仍然保留了 `Item` 接口，只是标记了废弃，使得开发者们无须修改旧的代码即可兼容。虽然它不再被使用，但即使使用了它也是没关系的，它是无用的、无害的，不会产生任何影响。