### PR TITLE
Removed the notifyDataSetChanged from setItems

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ dependencies {
 }
 ```
 
-**NOTE**: If you are updating from v2.4.0 to v2.4.1,
-note that the `setItems(items)` method removes the `notifyDataSetChanged()`
-and you need to call it yourself.
+**NOTE**: If you are updating from **v2.4.0** to v2.4.1,
+note that the `setItems(items)` method has removed the `notifyDataSetChanged()`
+and you need to call it by yourself.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ In your `build.gradle`:
 
 ```groovy
 dependencies {
-    compile 'me.drakeet.multitype:multitype:2.4.0'
+    compile 'me.drakeet.multitype:multitype:2.4.1'
 }
 ```
+
+**NOTE**: If you are updating from v2.4.0 to v2.4.1,
+note that the `setItems(items)` method removes the `notifyDataSetChanged()`
+and you need to call it yourself.
 
 ## Usage
 
@@ -101,6 +105,7 @@ public class NormalActivity extends AppCompatActivity {
             items.add(richItem);
         }
         adapter.setItems(items);
+        adapter.notifyDataSetChanged();
     }
 }
 ```

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,8 +25,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 25
-        versionCode 60
-        versionName "2.4.0"
+        versionCode 61
+        versionName "2.4.1"
     }
     buildTypes {
         release {

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -37,8 +37,8 @@ POM_NAME=MultiType
 POM_ARTIFACT_ID=multitype
 POM_PACKAGING=aar
 
-VERSION_NAME=2.4.0
-VERSION_CODE=60
+VERSION_NAME=2.4.1
+VERSION_CODE=61
 GROUP=me.drakeet.multitype
 
 POM_DESCRIPTION=An Android library to retrofit multiple item view types

--- a/library/src/main/java/me/drakeet/multitype/MultiTypeAdapter.java
+++ b/library/src/main/java/me/drakeet/multitype/MultiTypeAdapter.java
@@ -67,15 +67,18 @@ public class MultiTypeAdapter extends RecyclerView.Adapter<ViewHolder>
 
 
     /**
-     * Update the items and views atomically and safely.
+     * Update the items atomically and safely.
      * It is recommended to use this method to update the data.
+     * <p>e.g. {@code adapter.setItems(new Items(changedItems));}</p>
+     *
+     * <p>Note: If you want to refresh the list views, you should
+     * call {@link RecyclerView.Adapter#notifyDataSetChanged()} by yourself.</p>
      *
      * @param items The <b>new</b> items list.
-     * @since v2.4.0
+     * @since v2.4.1
      */
     public void setItems(@Nullable List<?> items) {
         this.items = items;
-        notifyDataSetChanged();
     }
 
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId "me.drakeet.multitype.sample"
         minSdkVersion 14
         targetSdkVersion 25
-        versionCode 60
-        versionName "2.4.0"
+        versionCode 61
+        versionName "2.4.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/sample/src/main/java/me/drakeet/multitype/sample/bilibili/BilibiliActivity.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/bilibili/BilibiliActivity.java
@@ -104,6 +104,7 @@ public class BilibiliActivity extends MenuBaseActivity {
             items.add(new PostList(data.postList));
         }
         adapter.setItems(items);
+        adapter.notifyDataSetChanged();
     }
 
 

--- a/sample/src/main/java/me/drakeet/multitype/sample/communicate_with_provider/SimpleActivity.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/communicate_with_provider/SimpleActivity.java
@@ -52,6 +52,7 @@ public class SimpleActivity extends MenuBaseActivity {
             items.add(new TextItem(valueOf(i)));
         }
         adapter.setItems(items);
+        adapter.notifyDataSetChanged();
 
         assertAllRegistered(adapter, items);
     }

--- a/sample/src/main/java/me/drakeet/multitype/sample/multi_select/MultiSelectActivity.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/multi_select/MultiSelectActivity.java
@@ -81,6 +81,7 @@ public class MultiSelectActivity extends MenuBaseActivity {
             items.add(new Square(i + 1));
         }
         adapter.setItems(items);
+        adapter.notifyDataSetChanged();
     }
 
 

--- a/sample/src/main/java/me/drakeet/multitype/sample/normal/NormalActivity.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/normal/NormalActivity.java
@@ -41,6 +41,7 @@ public class NormalActivity extends MenuBaseActivity {
         adapter = new MultiTypeAdapter();
         adapter.applyGlobalMultiTypePool();
         adapter.register(RichItem.class, new RichItemViewProvider());
+        recyclerView.setAdapter(adapter);
 
         TextItem textItem = new TextItem("world");
         ImageItem imageItem = new ImageItem(R.mipmap.ic_launcher);
@@ -53,7 +54,6 @@ public class NormalActivity extends MenuBaseActivity {
             items.add(richItem);
         }
         adapter.setItems(items);
-
-        recyclerView.setAdapter(adapter);
+        adapter.notifyDataSetChanged();
     }
 }

--- a/sample/src/main/java/me/drakeet/multitype/sample/one2many/OneDataToManyActivity.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/one2many/OneDataToManyActivity.java
@@ -56,6 +56,7 @@ public class OneDataToManyActivity extends MenuBaseActivity {
         //     data.typeClass = Data.getTypeClass(data.type);
         // }
         adapter.setItems(dataList);
+        adapter.notifyDataSetChanged();
         assertAllRegistered(adapter, dataList);
         recyclerView.setAdapter(adapter);
         assertHasTheSameAdapter(recyclerView, adapter);

--- a/sample/src/main/java/me/drakeet/multitype/sample/weibo/WeiboActivity.java
+++ b/sample/src/main/java/me/drakeet/multitype/sample/weibo/WeiboActivity.java
@@ -72,12 +72,13 @@ public class WeiboActivity extends MenuBaseActivity {
         setContentView(R.layout.activity_list);
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.list);
 
-        items = new Items();
         /* WeiboAdapter! */
         adapter = new WeiboAdapter();
         adapter.register(SimpleText.class, new SimpleTextViewProvider());
         adapter.register(SimpleImage.class, new SimpleImageViewProvider());
         recyclerView.setAdapter(adapter);
+
+        items = new Items();
 
         User user = new User("drakeet", R.mipmap.avatar);
         SimpleText simpleText = new SimpleText("A simple text Weibo: Hello World.");
@@ -87,6 +88,7 @@ public class WeiboActivity extends MenuBaseActivity {
             items.add(new Weibo(user, simpleImage));
         }
         adapter.setItems(items);
+        adapter.notifyDataSetChanged();
 
         assertAllRegistered(adapter, items);
 
@@ -95,9 +97,12 @@ public class WeiboActivity extends MenuBaseActivity {
 
 
     private void loadRemoteData() {
-        RemoteData dataFromParser = GsonProvider.gson.fromJson(JSON_FROM_SERVICE,
-            RemoteData.class);
+        RemoteData dataFromParser = GsonProvider.gson.fromJson(
+            JSON_FROM_SERVICE, RemoteData.class);
+        // Update the items atomically and safely.
+        items = new Items(items);
         items.addAll(0, dataFromParser.weibos);
+        adapter.setItems(items);
         adapter.notifyDataSetChanged();
     }
 


### PR DESCRIPTION
**NOTE**: If you are updating from **v2.4.0** to v2.4.1,
note that the `setItems(items)` method has removed the `notifyDataSetChanged()`
and you need to call it by yourself.