### PR TITLE
Fixed TravisCI

### DIFF
--- a/sample/src/androidTest/kotlin/com/drakeet/multitype/sample/SmokeTest.kt
+++ b/sample/src/androidTest/kotlin/com/drakeet/multitype/sample/SmokeTest.kt
@@ -46,11 +46,11 @@ class SmokeTest {
     "NormalActivity",
     "MultiSelectableActivity",
     "communicate with binder",
+    "BilibiliActivity",
     "WeiboActivity",
     "OneDataToManyActivity",
     "TestPayloadActivity",
-    "MoreApisPlayground",
-    "ContentViewActivity"
+    "MoreApisPlayground"
   )
 
   @Test


### PR DESCRIPTION
#267 has removed ContentViewActivity.kt and it's menu item but SmokeTest.kt still use ContentViewActivity to connectedAndroidTest so Travis could not work as wished. 
This PR is to solve it.