### PR TITLE
Fixed string expression's error in OneDataToManyActivity

### DIFF
--- a/sample/src/main/kotlin/com/drakeet/multitype/sample/one2many/OneDataToManyActivity.kt
+++ b/sample/src/main/kotlin/com/drakeet/multitype/sample/one2many/OneDataToManyActivity.kt
@@ -41,7 +41,7 @@ class OneDataToManyActivity : MenuBaseActivity() {
       var i = 0
       while (i < 30) {
         list.add(Data("title: $i", Data.TYPE_1))
-        list.add(Data("title: " + i + 1, Data.TYPE_2))
+        list.add(Data("title: ${ i + 1 }", Data.TYPE_2))
         i += 2
       }
       return list


### PR DESCRIPTION
Use **String Templates** instead of **String plus operator** in OneDataToManyActivity's string expression to fixed #276 